### PR TITLE
Fix build warning about conflicting NuGet versions

### DIFF
--- a/src/Content/NetCoreTool.Template.WebApi/CSharp/.template.config/template.json
+++ b/src/Content/NetCoreTool.Template.WebApi/CSharp/.template.config/template.json
@@ -434,6 +434,10 @@
       "description": "Add a connector for MySQL databases using ADO.NET.",
       "defaultValue": "false"
     },
+    "HasConnectorMySqlWithoutEfCore": {
+      "type": "computed",
+      "value": "ConnectorMySqlOption && (!ConnectorMySqlEfCoreOption)"
+    },
     "HasConnectorMySqlInSteeltoeV3": {
       "type": "computed",
       "value": "ConnectorMySqlOption && IsSteeltoeV3"
@@ -472,6 +476,10 @@
       "description": "Add a connector for PostgreSQL databases using ADO.NET.",
       "defaultValue": "false"
     },
+    "HasConnectorPostgreSqlWithoutEfCore": {
+      "type": "computed",
+      "value": "ConnectorPostgreSqlOption && (!ConnectorPostgreSqlEfCoreOption)"
+    },
     "HasConnectorPostgreSqlInSteeltoeV3": {
       "type": "computed",
       "value": "ConnectorPostgreSqlOption && IsSteeltoeV3"
@@ -500,6 +508,10 @@
       "description": "Add a connector for RabbitMQ message brokers.",
       "defaultValue": "false"
     },
+    "HasConnectorRabbitMqWithoutMessaging": {
+      "type": "computed",
+      "value": "ConnectorRabbitMqOption && (!HasAnyMessagingRabbitMqInSteeltoeV3)"
+    },
     "HasConnectorRabbitMqInSteeltoeV3": {
       "type": "computed",
       "value": "ConnectorRabbitMqOption && IsSteeltoeV3"
@@ -527,6 +539,10 @@
       "datatype": "bool",
       "description": "Add a connector for Microsoft SQL Server databases using ADO.NET.",
       "defaultValue": "false"
+    },
+    "HasConnectorSqlServerWithoutEfCore": {
+      "type": "computed",
+      "value": "ConnectorSqlServerOption && (!ConnectorSqlServerEfCoreOption)"
     },
     "HasConnectorSqlServerInSteeltoeV3": {
       "type": "computed",

--- a/src/Content/NetCoreTool.Template.WebApi/CSharp/Company.WebApplication.CS.csproj
+++ b/src/Content/NetCoreTool.Template.WebApi/CSharp/Company.WebApplication.CS.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>$(FrameworkOption)</TargetFramework>
@@ -28,17 +28,17 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Cosmos" Condition="'$(ConnectorCosmosDbOption)' == 'True'" Version="3.47.*" />
     <PackageReference Include="Microsoft.Azure.SpringCloud.Client" Condition="'$(HasHostingAzureSpringCloudInSteeltoeV3)' == 'True'" Version="2.0.0-preview.3" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Condition="'$(ConnectorSqlServerOption)' == 'True'" Version="$(SqlClientVersion)" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Condition="'$(HasConnectorSqlServerWithoutEfCore)' == 'True'" Version="$(SqlClientVersion)" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Condition="'$(HasAnyEfCoreConnector)' == 'True'" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Condition="'$(ConnectorSqlServerEfCoreOption)' == 'True'" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Condition="'$(ConnectorRedisOption)' == 'True'" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="MongoDB.Driver" Condition="'$(ConnectorMongoDbOption)' == 'True'" Version="3.2.*" />
-    <PackageReference Include="MySql.Data" Condition="'$(ConnectorMySqlOption)' == 'True'" Version="$(MySqlVersion)" />
+    <PackageReference Include="MySql.Data" Condition="'$(HasConnectorMySqlWithoutEfCore)' == 'True'" Version="$(MySqlVersion)" />
     <PackageReference Include="MySql.EntityFrameworkCore" Condition="'$(ConnectorMySqlEfCoreOption)' == 'True'" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Newtonsoft.Json" Condition="'$(ConnectorCosmosDbOption)' == 'True'" Version="13.0.*" />
-    <PackageReference Include="Npgsql" Condition="'$(ConnectorPostgreSqlOption)' == 'True'" Version="$(AspNetCoreVersion)" />
+    <PackageReference Include="Npgsql" Condition="'$(HasConnectorPostgreSqlWithoutEfCore)' == 'True'" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Condition="'$(ConnectorPostgreSqlEfCoreOption)' == 'True'" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="RabbitMQ.Client" Condition="'$(ConnectorRabbitMqOption)' == 'True'" Version="$(RabbitMqVersion)" />
+    <PackageReference Include="RabbitMQ.Client" Condition="'$(HasConnectorRabbitMqWithoutMessaging)' == 'True'" Version="$(RabbitMqVersion)" />
     <PackageReference Include="Steeltoe.CircuitBreaker.HystrixCore" Condition="'$(HasCircuitBreakerHystrixInSteeltoeV3)' == 'True'" Version="$(SteeltoeVersion)" />
     <PackageReference Include="Steeltoe.CircuitBreaker.Hystrix.MetricsStreamCore" Condition="'$(HasCircuitBreakerHystrixInSteeltoeV3)' == 'True'" Version="$(SteeltoeVersion)" />
     <PackageReference Include="Steeltoe.Configuration.CloudFoundry" Condition="'$(HasHostingCloudFoundryInSteeltoeV4)' == 'True'" Version="$(SteeltoeVersion)" />


### PR DESCRIPTION
This PR fixes the following build warning when both `ConnectorMySqlOption` and `ConnectorMySqlEfCoreOption` are selected as dependencies:

```text
Sample.csproj : error NU1605: Warning As Error: Detected package downgrade: MySql.Data from 9.4.0 to 9.3.0. Reference the package directly from the project to select a different version. 
Sample.csproj : error NU1605:  Sample -> MySql.EntityFrameworkCore 9.0.6 -> MySql.Data (>= 9.4.0) 
Sample.csproj : error NU1605:  Sample -> MySql.Data (>= 9.3.0)
```

This happens because new versions of Oracle MySQL packages were released to NuGet:
- `MySql.EntityFrameworkCore` 9.0.3 references `MySql.Data` 9.3.0
- NEW: `MySql.EntityFrameworkCore` 9.0.6 references `MySql.Data` 9.4.0

The generated project references `MySql.EntityFrameworkCore` 9.0.*, so it picks the new version. This conflicts with the hard-coded version we use for `MySql.Data`, which is still at 9.3.0. This hardcoded version is needed because `Steeltoe.Connectors` does not reference driver packages.

To fix this, we should _not_ reference assemblies that are transitively referenced.

This means:
- Do not reference `Microsoft.Data.SqlClient`, which is transitively referenced by `Microsoft.EntityFrameworkCore.SqlServer`
- Do not reference `MySql.Data`, which is transitively referenced by `MySql.EntityFrameworkCore`
- Do not reference `Npgsql`, which is transitively referenced by `Npgsql.EntityFrameworkCore.PostgreSQL`
- Do not reference `RabbitMQ.Client`, which is transitively referenced by `Steeltoe.Messaging.RabbitMQ`

Unfortunately, this can't be tested with the current test framework, because:
- There's no support to test a _combination_ of options.
- There's no way to assert a NuGet reference does _not_ exist.

So I tested this manually.